### PR TITLE
Using custom fields to preserve ENUM types from postgres schema

### DIFF
--- a/guac_auth/fields.py
+++ b/guac_auth/fields.py
@@ -1,0 +1,43 @@
+from django.db import models
+
+
+class EnumField(models.Field):
+    description = "enumerated type"
+
+    def __init__(self, *args, **kwargs):
+        self.enum = kwargs['enum']
+        del kwargs['enum']
+        super(EnumField, self).__init__(*args, **kwargs)
+
+    def db_type(self, connection):
+        return self.enum
+
+
+class GuacamoleConnectionGroupTypeField(EnumField):
+    description = 'enumerated type for connection groups'
+
+    def __init__(self, *args, **kwargs):
+        self.enum = 'guacamole_connection_group_type'
+        kwargs['enum'] = self.enum
+        super(GuacamoleConnectionGroupTypeField,
+              self).__init__(*args, **kwargs)
+
+
+class GuacamoleObjectPermissionTypeField(EnumField):
+    description = 'enumerated type for object permissions'
+
+    def __init__(self, *args, **kwargs):
+        self.enum = 'guacamole_object_permission_type'
+        kwargs['enum'] = self.enum
+        super(GuacamoleObjectPermissionTypeField,
+              self).__init__(*args, **kwargs)
+
+
+class GuacamoleSystemPermissionTypeField(EnumField):
+    description = 'enumerated type for system permissions'
+
+    def __init__(self, *args, **kwargs):
+        self.enum = 'guacamole_system_permission_type'
+        kwargs['enum'] = self.enum
+        super(GuacamoleSystemPermissionTypeField,
+              self).__init__(*args, **kwargs)

--- a/guac_auth/migrations/0002_auto_20160128_1752.py
+++ b/guac_auth/migrations/0002_auto_20160128_1752.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('guac_auth', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='guacamoleconnectiongroup',
+            name='type',
+        ),
+        migrations.AlterUniqueTogether(
+            name='guacamoleconnectiongrouppermission',
+            unique_together=set([]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='guacamoleconnectionpermission',
+            unique_together=set([]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='guacamolesystempermission',
+            unique_together=set([]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='guacamoleuserpermission',
+            unique_together=set([]),
+        ),
+        migrations.RemoveField(
+            model_name='guacamoleconnectiongrouppermission',
+            name='permission',
+        ),
+        migrations.RemoveField(
+            model_name='guacamoleconnectionpermission',
+            name='permission',
+        ),
+        migrations.RemoveField(
+            model_name='guacamolesystempermission',
+            name='permission',
+        ),
+        migrations.RemoveField(
+            model_name='guacamoleuserpermission',
+            name='permission',
+        ),
+    ]

--- a/guac_auth/migrations/0003_auto_20160128_1757.py
+++ b/guac_auth/migrations/0003_auto_20160128_1757.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models, connection
+import guac_auth.fields
+
+
+class Migration(migrations.Migration):
+
+    def enums_forward(apps, schema_editor):
+        # SQLite (tests) does not have ENUMs, so don't run then during tests.
+        # Required for Postgres however.
+        if schema_editor.connection.vendor == 'sqlite':
+            return
+        cursor = connection.cursor()
+
+        cursor.execute("CREATE TYPE guacamole_connection_group_type AS ENUM( 'ORGANIZATIONAL', 'BALANCING');")
+        cursor.execute("CREATE TYPE guacamole_object_permission_type AS ENUM( 'READ', 'UPDATE', 'DELETE', 'ADMINISTER');")
+        cursor.execute("CREATE TYPE guacamole_system_permission_type AS ENUM( 'CREATE_CONNECTION', 'CREATE_CONNECTION_GROUP', 'CREATE_USER', 'ADMINISTER');")
+
+    def enums_reverse(apps, schema_editor):
+        # SQLite (tests) does not have ENUMs, so don't run then during tests.
+        # Required for Postgres however.
+        if schema_editor.connection.vendor == 'sqlite':
+            return
+        cursor = connection.cursor()
+
+        cursor.execute("DROP TYPE guacamole_connection_group_type")
+        cursor.execute("DROP TYPE guacamole_object_permission_type")
+        cursor.execute("DROP TYPE guacamole_system_permission_type")
+
+    dependencies = [
+        ('guac_auth', '0002_auto_20160128_1752'),
+    ]
+
+    operations = [
+        migrations.RunPython(enums_forward, enums_reverse),
+        migrations.AddField(
+            model_name='guacamoleconnectiongroup',
+            name='type',
+            field=guac_auth.fields.GuacamoleConnectionGroupTypeField(default=b'ORGANIZATIONAL', choices=[(b'ORGANIZATIONAL', b'ORGANIZATIONAL'), (b'BALANCING', b'BALANCING')]),
+        ),
+        migrations.AddField(
+            model_name='guacamoleconnectiongrouppermission',
+            name='permission',
+            field=guac_auth.fields.GuacamoleObjectPermissionTypeField(default=b'READ', choices=[(b'READ', b'READ'), (b'UPDATE', b'UPDATE'), (b'DELETE', b'DELETE'), (b'ADMINISTER', b'ADMINISTER')]),
+        ),
+        migrations.AddField(
+            model_name='guacamoleconnectionpermission',
+            name='permission',
+            field=guac_auth.fields.GuacamoleObjectPermissionTypeField(default=b'READ', choices=[(b'READ', b'READ'), (b'UPDATE', b'UPDATE'), (b'DELETE', b'DELETE'), (b'ADMINISTER', b'ADMINISTER')]),
+        ),
+        migrations.AddField(
+            model_name='guacamolesystempermission',
+            name='permission',
+            field=guac_auth.fields.GuacamoleSystemPermissionTypeField(default=b'CREATE_CONNECTION', choices=[(b'CREATE_CONNECTION', b'CREATE_CONNECTION'), (b'CREATE_CONNECTION_GROUP', b'CREATE_CONNECTION_GROUP'), (b'CREATE_USER', b'CREATE_USER'), (b'ADMINISTER', b'ADMINISTER')]),
+        ),
+        migrations.AddField(
+            model_name='guacamoleuserpermission',
+            name='permission',
+            field=guac_auth.fields.GuacamoleObjectPermissionTypeField(default=b'READ', choices=[(b'READ', b'READ'), (b'UPDATE', b'UPDATE'), (b'DELETE', b'DELETE'), (b'ADMINISTER', b'ADMINISTER')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='guacamoleconnectiongrouppermission',
+            unique_together=set([('user', 'connection_group', 'permission')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='guacamoleconnectionpermission',
+            unique_together=set([('user', 'connection', 'permission')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='guacamolesystempermission',
+            unique_together=set([('user', 'permission')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='guacamoleuserpermission',
+            unique_together=set([('user', 'affected_user', 'permission')]),
+        ),
+    ]

--- a/guac_auth/models.py
+++ b/guac_auth/models.py
@@ -1,6 +1,9 @@
 from django.db import models
 from django.contrib.auth.models import User
 
+from .fields import GuacamoleConnectionGroupTypeField
+from .fields import GuacamoleObjectPermissionTypeField
+from .fields import GuacamoleSystemPermissionTypeField
 
 connection_group_type = (
     ('ORGANIZATIONAL', 'ORGANIZATIONAL'),
@@ -28,11 +31,8 @@ class GuacamoleConnectionGroup(models.Model):
         blank=True,
         null=True)
     connection_group_name = models.CharField(max_length=128)
-    type = models.CharField(
-        max_length=128,
+    type = GuacamoleConnectionGroupTypeField(
         choices=connection_group_type,
-        null=False,
-        blank=False,
         default='ORGANIZATIONAL')
     max_connections = models.IntegerField(blank=True, null=True)
     max_connections_per_user = models.IntegerField(blank=True, null=True)
@@ -85,8 +85,7 @@ class GuacamoleConnectionGroupPermission(models.Model):
         GuacamoleUser,
         related_name='connection_group_permissions')
     connection_group = models.ForeignKey(GuacamoleConnectionGroup)
-    permission = models.CharField(
-        max_length=128,
+    permission = GuacamoleObjectPermissionTypeField(
         choices=object_permission_type,
         default='READ')
 
@@ -132,8 +131,7 @@ class GuacamoleConnectionPermission(models.Model):
         GuacamoleConnection,
         related_name='connection_permissions',
         on_delete=models.CASCADE)
-    permission = models.CharField(
-        max_length=128,
+    permission = GuacamoleObjectPermissionTypeField(
         choices=object_permission_type,
         default='READ')
 
@@ -146,9 +144,9 @@ class GuacamoleSystemPermission(models.Model):
     user = models.ForeignKey(
         GuacamoleUser,
         related_name='system_permissions')
-    permission = models.CharField(
-        max_length=128,
-        choices=system_permission_type)
+    permission = GuacamoleSystemPermissionTypeField(
+        choices=system_permission_type,
+        default='CREATE_CONNECTION')
 
     class Meta:
         db_table = 'guacamole_system_permission'
@@ -162,8 +160,7 @@ class GuacamoleUserPermission(models.Model):
     affected_user = models.ForeignKey(
         GuacamoleUser,
         related_name='affected_perms')
-    permission = models.CharField(
-        max_length=128,
+    permission = GuacamoleObjectPermissionTypeField(
         choices=object_permission_type,
         default='READ')
 

--- a/guac_auth/tests.py
+++ b/guac_auth/tests.py
@@ -28,6 +28,7 @@ class SimpleTestCase(TestCase):
 
         self.assertEquals(gcp.user.username, "guacman")
         self.assertEquals(gcp.connection.protocol, "rdp")
+        self.assertEquals(gcp.permission, "READ")
 
         hostname_parameter = gcp.connection.parameters.get(
             parameter_name='hostname')

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     packages=find_packages(exclude=["tests", ]),
     install_requires=[
         'django>=1.8,<1.9',
+        'sqlparse'
     ],
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
I was not aware that the guacamole client (the war file) would use the
custom ENUM types at the top of the file (as opposed to just checking
for string equality).

To preserve these, I utilized custom fields based on this presentation
here:
https://wiki.postgresql.org/images/0/0b/Postgresql_django_extensions.pdf

Each of the models switched out CharFields for these EnumFields.

Because A) we could not automatically migrate the data and B) no one is
using (successfully) this project yet, we included two migrations, one
(0002) to remove the offending fields, and another (0003) to add in the
correct ones.

Because of the method by which we add the actual ENUM types themselves
in 0003, we needed to include sqlparse in the requirements.

Finally, our test was buffed up a little bit to prove we can still do
string comparison at the application level.
